### PR TITLE
Allow arbitrary string session IDs instead of GUID-only

### DIFF
--- a/AgentManager/Components/Pages/Messages.razor
+++ b/AgentManager/Components/Pages/Messages.razor
@@ -22,7 +22,7 @@
         <MudSelect T="string" ValueChanged="OnSelect">
             @foreach (var session in sessions)
             {
-                <MudSelectItem Value="@session.Id.ToString()">@session.AgentName (@(@session.SessionName ?? @session.Id.ToString()))</MudSelectItem>
+                <MudSelectItem Value="@session.Id">@session.AgentName (@(session.SessionName ?? session.Id))</MudSelectItem>
             }
         </MudSelect>
 
@@ -45,7 +45,7 @@
     private ObservableCollection<AgentSession> sessions = new();
     private ObservableCollection<AgentMessage> messages = new();
 
-    private Guid? sessionId;
+    private string? sessionId;
     private AgentSession? session;
 
     protected override async Task OnInitializedAsync()
@@ -71,17 +71,17 @@
     private async Task OnSelect(string value)
     {
         sessionId = null;
-        if (!Guid.TryParse(value, out var id))
+        if (string.IsNullOrEmpty(value))
         {
             return;
         }
 
-        sessionId = id;
-        session = await AgentSessionService.GetSessionById(id);
+        sessionId = value;
+        session = await AgentSessionService.GetSessionById(value);
 
         this.messages.Clear();
 
-        var messages = await AgentMessageService.GetSessionMessages(id);
+        var messages = await AgentMessageService.GetSessionMessages(value);
         foreach (var message in messages)
         {
             this.messages.Add(message);
@@ -97,7 +97,7 @@
 
         foreach (var message in messages)
         {
-            if (!Guid.Equals(message.Session.Id, sessionId))
+            if (!string.Equals(message.Session.Id, sessionId))
             {
                 return;
             }

--- a/AgentManager/Components/Pages/Sessions.razor
+++ b/AgentManager/Components/Pages/Sessions.razor
@@ -26,11 +26,61 @@
     }
     else
     {
-        <MudDataGrid Items="@sessions" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@loading">
+        <MudDataGrid Items="@sessions" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@loading"
+                     Sortable="true" Filterable="true">
             <Columns>
+                <PropertyColumn Property="x => x.SessionName" Title="Name" />
                 <PropertyColumn Property="x => x.AgentName" Title="Agent" />
-                <PropertyColumn Property="x => x.Id" Title="Id" />
-                <PropertyColumn Property="x => x.Status" Title="Status" />
+                <PropertyColumn Property="x => x.Status" Title="Status">
+                    <CellTemplate>
+                        <MudChip T="string"
+                                 Color="@GetStatusColor(context.Item.Status)"
+                                 Size="Size.Small"
+                                 Variant="Variant.Filled">
+                            @context.Item.Status
+                        </MudChip>
+                    </CellTemplate>
+                </PropertyColumn>
+                <PropertyColumn Property="x => x.Persistent" Title="Persistent" Sortable="true">
+                    <CellTemplate>
+                        @if (context.Item.Persistent)
+                        {
+                            <MudIcon Icon="@Icons.Material.Filled.Lock" Size="Size.Small" Color="Color.Default" />
+                        }
+                        else
+                        {
+                            <MudText Typo="Typo.body2" Color="Color.Default">—</MudText>
+                        }
+                    </CellTemplate>
+                </PropertyColumn>
+                <TemplateColumn Title="Last Active" Sortable="true" SortBy="x => x.UpdatedAt ?? x.CreatedAt">
+                    <CellTemplate>
+                        <MudText Typo="Typo.body2">
+                            @GetRelativeTime(context.Item.UpdatedAt ?? context.Item.CreatedAt)
+                        </MudText>
+                    </CellTemplate>
+                </TemplateColumn>
+                <PropertyColumn Property="x => x.CreatedAt" Title="Created" Sortable="true">
+                    <CellTemplate>
+                        <MudText Typo="Typo.body2">
+                            @context.Item.CreatedAt.ToLocalTime().ToString("MMM d, yyyy HH:mm")
+                        </MudText>
+                    </CellTemplate>
+                </PropertyColumn>
+                <TemplateColumn Title="Messages" Sortable="true" SortBy="x => GetMessageCount(x.Id)">
+                    <CellTemplate>
+                        <MudText Typo="Typo.body2">
+                            @GetMessageCount(context.Item.Id)
+                        </MudText>
+                    </CellTemplate>
+                </TemplateColumn>
+                <TemplateColumn Title="Last Message">
+                    <CellTemplate>
+                        <MudText Typo="Typo.body2" Style="max-width: 200px;" Class="truncate-text">
+                            @(GetLastMessagePreview(context.Item.Id) ?? "—")
+                        </MudText>
+                    </CellTemplate>
+                </TemplateColumn>
                 <AuthorizeView Roles="Admin">
                     <Authorized>
                         <TemplateColumn Title="Actions" CellClass="d-flex justify-center">
@@ -49,8 +99,17 @@
     }
 </MudContainer>
 
+<style>
+    .truncate-text {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+</style>
+
 @code {
     private ObservableCollection<AgentSession> sessions = new();
+    private Dictionary<string, (int MessageCount, string? LastPreview)> sessionStats = new();
     private bool loading = false;
     private bool subscribedToChanges = false;
 
@@ -76,12 +135,73 @@
     private async Task LoadSessionsAsync()
     {
         sessions.Clear();
+        sessionStats.Clear();
         loading = true;
-        foreach (var s in await AgentSessionService.GetAllAsync())
+
+        var allSessions = await AgentSessionService.GetAllAsync();
+        foreach (var s in allSessions)
         {
             sessions.Add(s);
         }
+
+        var stats = await AgentSessionService.GetSessionStatsAsync();
+        foreach (var stat in stats)
+        {
+            sessionStats[stat.Key] = stat.Value;
+        }
+
         loading = false;
+    }
+
+    private int GetMessageCount(string sessionId)
+    {
+        return sessionStats.TryGetValue(sessionId, out var stats) ? stats.MessageCount : 0;
+    }
+
+    private string? GetLastMessagePreview(string sessionId)
+    {
+        if (sessionStats.TryGetValue(sessionId, out var stats) && !string.IsNullOrEmpty(stats.LastPreview))
+        {
+            var preview = stats.LastPreview;
+            if (preview.Length > 50)
+            {
+                preview = preview.Substring(0, 50) + "...";
+            }
+            return preview;
+        }
+        return null;
+    }
+
+    private string GetRelativeTime(DateTime dateTime)
+    {
+        var localTime = dateTime.ToLocalTime();
+        var now = DateTime.Now;
+        var diff = now - localTime;
+
+        if (diff.TotalSeconds < 60)
+            return "just now";
+        if (diff.TotalMinutes < 60)
+            return $"{(int)diff.TotalMinutes}m ago";
+        if (diff.TotalHours < 24)
+            return $"{(int)diff.TotalHours}h ago";
+        if (diff.TotalDays < 7)
+            return $"{(int)diff.TotalDays}d ago";
+
+        return localTime.ToString("MMM d");
+    }
+
+    private Color GetStatusColor(string status)
+    {
+        return status.ToUpperInvariant() switch
+        {
+            "NEW" => Color.Info,
+            "CONNECTED" => Color.Success,
+            "ACTIVE" => Color.Success,
+            "IDLE" => Color.Warning,
+            "DISCONNECTED" => Color.Default,
+            "ERROR" => Color.Error,
+            _ => Color.Default
+        };
     }
 
     private async Task RemoveSessionAsync(AgentSession session)

--- a/AgentManager/Entities/SessionEntity.cs
+++ b/AgentManager/Entities/SessionEntity.cs
@@ -1,9 +1,8 @@
-
 namespace AgentManager.Entities;
 
 public class SessionEntity
 {
-    public required Guid Id { get; set; }
+    public required string Id { get; set; }
     public string? SessionName { get; set; }
     public required string AgentName { get; set; }
     public required string Status { get; set; }

--- a/AgentManager/Entities/SessionStateEntity.cs
+++ b/AgentManager/Entities/SessionStateEntity.cs
@@ -3,7 +3,7 @@ namespace AgentManager.Entities;
 public class SessionStateEntity
 {
     public required int Id { get; set; }
-    public required Guid SessionId { get; set; }
+    public required string SessionId { get; set; }
     public required string Key { get; set; }
     public required string Value { get; set; }
     public required DateTime UpdatedAt { get; set; }

--- a/AgentManager/Hubs/AgentHub.cs
+++ b/AgentManager/Hubs/AgentHub.cs
@@ -8,12 +8,12 @@ using Microsoft.AspNetCore.SignalR;
 
 namespace AgentManager.Hubs;
 
-public record RegisterSessionDto(Guid SessionId, string AgentName, bool Persistent);
-public record RegisterConnection(Guid SessionId, string ConnectionId, string? IpAddress);
-public record UpdateStatusDto(Guid SessionId, string Status);
-public record LogOperationDto(Guid SessionId, string Category, string Message, string Level);
-public record AddMessagesDto(Guid SessionId, ICollection<AgentMessage> Messages);
-public record SaveMessagesDto(Guid SessionId, ICollection<AgentMessage> Messages);
+public record RegisterSessionDto(string SessionId, string AgentName, bool Persistent);
+public record RegisterConnection(string SessionId, string ConnectionId, string? IpAddress);
+public record UpdateStatusDto(string SessionId, string Status);
+public record LogOperationDto(string SessionId, string Category, string Message, string Level);
+public record AddMessagesDto(string SessionId, ICollection<AgentMessage> Messages);
+public record SaveMessagesDto(string SessionId, ICollection<AgentMessage> Messages);
 
 [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
 public class AgentHub : Hub<IAgentClient>
@@ -33,51 +33,31 @@ public class AgentHub : Hub<IAgentClient>
 
     public async Task Register(string agentName, string sessionId, bool persistent)
     {
-        if (!Guid.TryParse(sessionId, out Guid id))
-        {
-            throw new ArgumentException("sessionId is not a GUID", nameof(sessionId));
-        }
-
-        var registerSession = new RegisterSessionDto(id, agentName, persistent);
-        var registerConnection = new RegisterConnection(id, Context.ConnectionId, Context.GetHttpContext()?.Connection.RemoteIpAddress?.ToString());
+        var registerSession = new RegisterSessionDto(sessionId, agentName, persistent);
+        var registerConnection = new RegisterConnection(sessionId, Context.ConnectionId, Context.GetHttpContext()?.Connection.RemoteIpAddress?.ToString());
         await agentSessionService.Register(registerSession, registerConnection);
     }
 
     public async Task UpdateStatus(string sessionId, string status)
     {
-        if (!Guid.TryParse(sessionId, out Guid id))
-        {
-            throw new ArgumentException("sessionId is not a GUID", nameof(sessionId));
-        }
-
-        var updateStatus = new UpdateStatusDto(id, status);
+        var updateStatus = new UpdateStatusDto(sessionId, status);
         await agentSessionService.UpdateStatusAsync(updateStatus);
     }
 
     public async Task Log(string sessionId, string category, string message, string level = "Info")
     {
-        if (!Guid.TryParse(sessionId, out Guid id))
-        {
-            throw new ArgumentException("sessionId is not a GUID", nameof(sessionId));
-        }
-
-        var session = await agentSessionService.GetSessionById(id);
+        var session = await agentSessionService.GetSessionById(sessionId);
         if (session == null)
         {
             throw new KeyNotFoundException();
         }
 
-        await agentLogService.Log(new LogOperationDto(id, category, message, level));
+        await agentLogService.Log(new LogOperationDto(sessionId, category, message, level));
     }
 
     public async Task AddMessages(string sessionId, string messageJson)
     {
-        if (!Guid.TryParse(sessionId, out Guid id))
-        {
-            throw new ArgumentException("sessionId is not a GUID", nameof(sessionId));
-        }
-
-        var session = await agentSessionService.GetSessionById(id);
+        var session = await agentSessionService.GetSessionById(sessionId);
         if (session == null)
         {
             throw new KeyNotFoundException();
@@ -91,18 +71,13 @@ public class AgentHub : Hub<IAgentClient>
             messages.Add(AgentMessage.Parse(element, session));
         }
 
-        await agentMessageService.AddMessages(new AddMessagesDto(id, messages));
-        await agentSessionService.UpdateTimestampAsync(id);
+        await agentMessageService.AddMessages(new AddMessagesDto(sessionId, messages));
+        await agentSessionService.UpdateTimestampAsync(sessionId);
     }
 
     public async Task SaveMessages(string sessionId, string messageJson)
     {
-        if (!Guid.TryParse(sessionId, out Guid id))
-        {
-            throw new ArgumentException("sessionId is not a GUID", nameof(sessionId));
-        }
-
-        var session = await agentSessionService.GetSessionById(id);
+        var session = await agentSessionService.GetSessionById(sessionId);
         if (session == null)
         {
             throw new KeyNotFoundException();
@@ -116,18 +91,13 @@ public class AgentHub : Hub<IAgentClient>
             messages.Add(AgentMessage.Parse(element, session));
         }
 
-        await agentMessageService.SaveMessages(new SaveMessagesDto(id, messages));
-        await agentSessionService.UpdateTimestampAsync(id);
+        await agentMessageService.SaveMessages(new SaveMessagesDto(sessionId, messages));
+        await agentSessionService.UpdateTimestampAsync(sessionId);
     }
 
     public async Task<string> GetMessages(string sessionId)
     {
-        if (!Guid.TryParse(sessionId, out Guid id))
-        {
-            throw new ArgumentException("sessionId is not a GUID", nameof(sessionId));
-        }
-
-        var session = await agentSessionService.GetSessionById(id);
+        var session = await agentSessionService.GetSessionById(sessionId);
         if (session == null)
         {
             throw new KeyNotFoundException();
@@ -135,7 +105,7 @@ public class AgentHub : Hub<IAgentClient>
 
         var jsonArray = new JsonArray();
 
-        var messages = await agentMessageService.GetSessionMessages(id);
+        var messages = await agentMessageService.GetSessionMessages(sessionId);
         foreach (var message in messages)
         {
             var jsonObject = JsonNode.Parse(message.Json);
@@ -147,12 +117,7 @@ public class AgentHub : Hub<IAgentClient>
 
     public async Task<string> GetLastUpdated(string sessionId)
     {
-        if (!Guid.TryParse(sessionId, out Guid id))
-        {
-            throw new ArgumentException("sessionId is not a GUID", nameof(sessionId));
-        }
-
-        var session = await agentSessionService.GetSessionById(id);
+        var session = await agentSessionService.GetSessionById(sessionId);
         if (session == null)
         {
             throw new KeyNotFoundException();
@@ -163,50 +128,35 @@ public class AgentHub : Hub<IAgentClient>
 
     public async Task<string?> GetState(string sessionId, string key)
     {
-        if (!Guid.TryParse(sessionId, out Guid id))
-        {
-            throw new ArgumentException(nameof(sessionId));
-        }
-
-        var session = await agentSessionService.GetSessionById(id);
+        var session = await agentSessionService.GetSessionById(sessionId);
         if (session == null)
         {
             throw new KeyNotFoundException();
         }
 
-        return await agentStateService.GetState(id, key);
+        return await agentStateService.GetState(sessionId, key);
     }
 
     public async Task SetState(string sessionId, string key, string value)
     {
-        if (!Guid.TryParse(sessionId, out Guid id))
-        {
-            throw new ArgumentException(nameof(sessionId));
-        }
-
-        var session = await agentSessionService.GetSessionById(id);
+        var session = await agentSessionService.GetSessionById(sessionId);
         if (session == null)
         {
             throw new KeyNotFoundException();
         }
 
-        await agentStateService.SetState(id, key, value);
+        await agentStateService.SetState(sessionId, key, value);
     }
 
     public async Task<Dictionary<string, string>> GetAllState(string sessionId)
     {
-        if (!Guid.TryParse(sessionId, out Guid id))
-        {
-            throw new ArgumentException(nameof(sessionId));
-        }
-
-        var session = await agentSessionService.GetSessionById(id);
+        var session = await agentSessionService.GetSessionById(sessionId);
         if (session == null)
         {
             throw new KeyNotFoundException();
         }
 
-        return await agentStateService.GetAllState(id);
+        return await agentStateService.GetAllState(sessionId);
     }
 
     public override async Task OnDisconnectedAsync(Exception? exception)

--- a/AgentManager/Migrations/20260417171644_ChangeSessionIdToString.Designer.cs
+++ b/AgentManager/Migrations/20260417171644_ChangeSessionIdToString.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AgentManager.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AgentManager.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260417171644_ChangeSessionIdToString")]
+    partial class ChangeSessionIdToString
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.14");

--- a/AgentManager/Migrations/20260417171644_ChangeSessionIdToString.cs
+++ b/AgentManager/Migrations/20260417171644_ChangeSessionIdToString.cs
@@ -1,0 +1,158 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AgentManager.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangeSessionIdToString : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Logs_Sessions_SessionId",
+                table: "Logs");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Messages_Sessions_SessionId",
+                table: "Messages");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_SessionStates_Sessions_SessionId",
+                table: "SessionStates");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Id",
+                table: "Sessions",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SessionId",
+                table: "SessionStates",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SessionId",
+                table: "Messages",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SessionId",
+                table: "Logs",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "TEXT");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Logs_Sessions_SessionId",
+                table: "Logs",
+                column: "SessionId",
+                principalTable: "Sessions",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Messages_Sessions_SessionId",
+                table: "Messages",
+                column: "SessionId",
+                principalTable: "Sessions",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SessionStates_Sessions_SessionId",
+                table: "SessionStates",
+                column: "SessionId",
+                principalTable: "Sessions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Logs_Sessions_SessionId",
+                table: "Logs");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Messages_Sessions_SessionId",
+                table: "Messages");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_SessionStates_Sessions_SessionId",
+                table: "SessionStates");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "Id",
+                table: "Sessions",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "SessionId",
+                table: "SessionStates",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "SessionId",
+                table: "Messages",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "SessionId",
+                table: "Logs",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Logs_Sessions_SessionId",
+                table: "Logs",
+                column: "SessionId",
+                principalTable: "Sessions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Messages_Sessions_SessionId",
+                table: "Messages",
+                column: "SessionId",
+                principalTable: "Sessions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SessionStates_Sessions_SessionId",
+                table: "SessionStates",
+                column: "SessionId",
+                principalTable: "Sessions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/AgentManager/Models/AgentConnection.cs
+++ b/AgentManager/Models/AgentConnection.cs
@@ -1,9 +1,8 @@
-
 namespace AgentManager.Models;
 
 public class AgentConnection
 {
-    public required Guid SessionId { get; set; }
+    public required string SessionId { get; set; }
     public required string ConnectionId { get; set; }
     public string? IpAddress { get; set; }
 }

--- a/AgentManager/Models/AgentSession.cs
+++ b/AgentManager/Models/AgentSession.cs
@@ -1,9 +1,8 @@
-
 namespace AgentManager.Models;
 
 public class AgentSession
 {
-    public required Guid Id { get; set; }
+    public required string Id { get; set; }
     public string? SessionName { get; set; }
     public required string AgentName { get; set; }
     public required string Status { get; set; }

--- a/AgentManager/Services/AgentLogService.cs
+++ b/AgentManager/Services/AgentLogService.cs
@@ -41,7 +41,7 @@ public class AgentLogService
         OnLog?.Invoke(log);
     }
 
-    public async Task<List<AgentLog>> GetLogs(Guid sessionId)
+    public async Task<List<AgentLog>> GetLogs(string sessionId)
     {
        var session = await agentSessionService.GetSessionById(sessionId);
        if (session == null)
@@ -73,7 +73,7 @@ public class AgentLogService
             var sessions = await agentSessionService.GetAllAsync();
             return logs.Select(log =>
             {
-                var session = sessions.Where(s => Equals(s.Id, log.Session.Id));
+                var session = sessions.Where(s => string.Equals(s.Id, log.Session.Id));
                 return new AgentLog
                 {
                     Category = log.Category,
@@ -85,7 +85,7 @@ public class AgentLogService
             }).ToList();
         }
 
-        public async Task<List<AgentLog>> GetLogs(Guid sessionId, AgentSession session)
+        public async Task<List<AgentLog>> GetLogs(string sessionId, AgentSession session)
         {
            using var db = await _dbFactory.CreateDbContextAsync();
            return await db.Logs

--- a/AgentManager/Services/AgentMessageService.cs
+++ b/AgentManager/Services/AgentMessageService.cs
@@ -58,7 +58,7 @@ public class AgentMessageService
         return messages;
     }
 
-    public async Task<List<AgentMessage>> GetSessionMessages(Guid sessionId)
+    public async Task<List<AgentMessage>> GetSessionMessages(string sessionId)
     {
         var session = await agentSessionService.GetSessionById(sessionId);
         if (session == null)
@@ -73,7 +73,7 @@ public class AgentMessageService
     {
         private readonly IDbContextFactory<AppDbContext> _dbFactory = dbContextFactory;
 
-        public async Task ReplaceAsync(Guid sessionId, ICollection<AgentMessage> messages)
+        public async Task ReplaceAsync(string sessionId, ICollection<AgentMessage> messages)
         {
             using var db = await _dbFactory.CreateDbContextAsync();
             var sessionEntity = db.Sessions.Find(sessionId);
@@ -99,7 +99,7 @@ public class AgentMessageService
             await db.SaveChangesAsync();
         }
 
-        public async Task InsertAsync(Guid sessionId, ICollection<AgentMessage> messages)
+        public async Task InsertAsync(string sessionId, ICollection<AgentMessage> messages)
         {
             using var db = await _dbFactory.CreateDbContextAsync();
             var sessionEntity = db.Sessions.Find(sessionId);

--- a/AgentManager/Services/AgentSessionService.cs
+++ b/AgentManager/Services/AgentSessionService.cs
@@ -12,7 +12,7 @@ public class AgentSessionService
 {
     private readonly Persistence persistence;
 
-    private readonly ConcurrentDictionary<Guid, AgentConnection> connections = new();
+    private readonly ConcurrentDictionary<string, AgentConnection> connections = new();
 
     public event Action<AgentSession>? OnChange;
 
@@ -26,12 +26,17 @@ public class AgentSessionService
         return await persistence.GetAllAsync();
     }
 
-    public async Task<AgentSession?> GetSessionById(Guid sessionId)
+    public async Task<Dictionary<string, (int MessageCount, string? LastMessagePreview)>> GetSessionStatsAsync()
+    {
+        return await persistence.GetSessionStatsAsync();
+    }
+
+    public async Task<AgentSession?> GetSessionById(string sessionId)
     {
         return await persistence.GetByIdAsync(sessionId);
     }
 
-    public async Task RemoveSessionAsync(Guid sessionId)
+    public async Task RemoveSessionAsync(string sessionId)
     {
         var session = await persistence.GetByIdAsync(sessionId);
         if (session == null)
@@ -77,7 +82,7 @@ public class AgentSessionService
         OnChange?.Invoke(session);
     }
 
-    public async Task Unregister(Guid sessionId)
+    public async Task Unregister(string sessionId)
     {
         var session = await persistence.GetByIdAsync(sessionId);
         if (session == null)
@@ -96,12 +101,12 @@ public class AgentSessionService
         OnChange?.Invoke(session);
     }
 
-    public async Task Unregister(string connectionId)
+    public async Task UnregisterByConnectionId(string connectionId)
     {
         var connection = connections.FirstOrDefault(x => string.Equals(x.Value.ConnectionId, connectionId));
         var key = connection.Key;
 
-        if (key != default)
+        if (key != null)
         {
             await Unregister(key);
         }
@@ -122,7 +127,7 @@ public class AgentSessionService
         OnChange?.Invoke(session);
     }
 
-    public async Task UpdateTimestampAsync(Guid sessionId)
+    public async Task UpdateTimestampAsync(string sessionId)
     {
         var session = await persistence.GetByIdAsync(sessionId);
         if (session == null)
@@ -149,7 +154,67 @@ public class AgentSessionService
             return sessions.Select(MapAgentSession).ToList();
         }
 
-        public async Task<AgentSession?> GetByIdAsync(Guid sessionId)
+        public async Task<Dictionary<string, (int MessageCount, string? LastMessagePreview)>> GetSessionStatsAsync()
+        {
+            using var db = await _dbFactory.CreateDbContextAsync();
+            var stats = new Dictionary<string, (int MessageCount, string? LastMessagePreview)>();
+
+            var sessions = await db.Sessions
+                .AsNoTracking()
+                .Select(s => s.Id)
+                .ToListAsync();
+
+            foreach (var sessionId in sessions)
+            {
+                var messages = await db.Messages
+                    .Where(m => m.Session.Id == sessionId)
+                    .OrderByDescending(m => m.Id)
+                    .AsNoTracking()
+                    .Select(m => m.Json)
+                    .ToListAsync();
+
+                var messageCount = messages.Count;
+                string? lastPreview = null;
+
+                if (messages.Count > 0)
+                {
+                    try
+                    {
+                        var lastJson = messages[0];
+                        var doc = System.Text.Json.JsonDocument.Parse(lastJson);
+                        var content = doc.RootElement.GetProperty("content");
+
+                        if (content.ValueKind == System.Text.Json.JsonValueKind.String)
+                        {
+                            lastPreview = content.GetString();
+                        }
+                        else if (content.ValueKind == System.Text.Json.JsonValueKind.Array)
+                        {
+                            foreach (var e in content.EnumerateArray())
+                            {
+                                if (e.TryGetProperty("type", out var type) &&
+                                    string.Equals(type.GetString(), "text") &&
+                                    e.TryGetProperty("text", out var text))
+                                {
+                                    lastPreview = text.GetString();
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    catch
+                    {
+                        // If parsing fails, leave lastPreview as null
+                    }
+                }
+
+                stats[sessionId] = (messageCount, lastPreview);
+            }
+
+            return stats;
+        }
+
+        public async Task<AgentSession?> GetByIdAsync(string sessionId)
         {
             using var db = await _dbFactory.CreateDbContextAsync();
             var sessionEntity = await db.Sessions.FindAsync(sessionId);
@@ -194,7 +259,7 @@ public class AgentSessionService
             await db.SaveChangesAsync();
         }
 
-        public async Task DeleteAsync(Guid sessionId)
+        public async Task DeleteAsync(string sessionId)
         {
             using var db = await _dbFactory.CreateDbContextAsync();
             var session = await db.Sessions.FindAsync(sessionId);

--- a/AgentManager/Services/AgentStateService.cs
+++ b/AgentManager/Services/AgentStateService.cs
@@ -15,17 +15,17 @@ public class AgentStateService
         persistence = new Persistence(dbFactory);
     }
 
-    public async Task<string?> GetState(Guid sessionId, string key)
+    public async Task<string?> GetState(string sessionId, string key)
     {
         return await persistence.GetState(sessionId, key);
     }
 
-    public async Task SetState(Guid sessionId, string key, string value)
+    public async Task SetState(string sessionId, string key, string value)
     {
         await persistence.SetState(sessionId, key, value);
     }
 
-    public async Task<Dictionary<string, string>> GetAllState(Guid sessionId)
+    public async Task<Dictionary<string, string>> GetAllState(string sessionId)
     {
         return await persistence.GetAllState(sessionId);
     }
@@ -34,7 +34,7 @@ public class AgentStateService
     {
         private readonly IDbContextFactory<AppDbContext> _dbFactory = dbContextFactory;
 
-        public async Task<string?> GetState(Guid sessionId, string key)
+        public async Task<string?> GetState(string sessionId, string key)
         {
             using var db = await _dbFactory.CreateDbContextAsync();
             var stateEntity = await db.SessionStates
@@ -43,7 +43,7 @@ public class AgentStateService
             return stateEntity?.Value;
         }
 
-        public async Task SetState(Guid sessionId, string key, string value)
+        public async Task SetState(string sessionId, string key, string value)
         {
             using var db = await _dbFactory.CreateDbContextAsync();
             var sessionEntity = db.Sessions.Find(sessionId);
@@ -77,7 +77,7 @@ public class AgentStateService
             await db.SaveChangesAsync();
         }
 
-        public async Task<Dictionary<string, string>> GetAllState(Guid sessionId)
+        public async Task<Dictionary<string, string>> GetAllState(string sessionId)
         {
             using var db = await _dbFactory.CreateDbContextAsync();
             var states = await db.SessionStates

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ A flexible agent framework for interacting with LLMs that are OpenAI API compati
 
 - **ConsoleAgent**: Run on the command line for interactive use.
 - **XmppAgent**: Run as a user on an XMPP server for real-time chat interactions.
+- **ToolTester**: Test individual tools interactively from the command line.
+- **ToolServer**: Expose tools via MCP (Model Context Protocol) over HTTP or stdio.
+- **AgentManager**: Web-based dashboard for managing agents.
 - Supports arbitrary tools via .NET assemblies.
 - Persistent message history for context retention.
 - Configurable via JSON files.
@@ -24,6 +27,30 @@ $ dotnet build
 ```
 
 This will build both `ConsoleAgent` and `XmppAgent`.
+
+### Test
+
+```bash
+# Run tests (excludes integration tests)
+$ dotnet test --configuration Release --verbosity normal --filter "TestCategory!=Integration"
+```
+
+### Integration Tests
+
+Integration tests are located in `LlmAgents.Tests/TestLlmAgent.cs` and make real API calls to an LLM provider. They are excluded from CI runs by default.
+
+**Requirements:**
+- `LLMAGENTS_API_KEY` - Your API key
+- `LLMAGENTS_API_ENDPOINT` - API endpoint URL (e.g., `https://api.openai.com/v1`)
+- `LLMAGENTS_API_MODEL` - Model name (e.g., `gpt-4`)
+
+**Run integration tests:**
+```bash
+$ export LLMAGENTS_API_KEY="your-api-key"
+$ export LLMAGENTS_API_ENDPOINT="https://api.openai.com/v1"
+$ export LLMAGENTS_API_MODEL="gpt-4"
+$ dotnet test --configuration Release --filter "TestCategory=Integration"
+```
 
 ## Configuration
 
@@ -89,7 +116,7 @@ After building, run:
 $ dotnet run --project ConsoleAgent
 ```
 
-You’ll be prompted to enter messages and interact with the LLM via the command line.
+You'll be prompted to enter messages and interact with the LLM via the command line.
 
 ### XmppAgent
 
@@ -101,10 +128,40 @@ $ dotnet run --project XmppAgent
 
 The agent will connect to the XMPP server and respond to messages sent to the configured JID.
 
+### ToolTester
+
+Interactive CLI to test individual tools:
+
+```bash
+$ dotnet run --project ToolTester -- --tools-config Agent/tools.json --working-directory /path/to/project
+```
+
+This will list available tools by number, let you select one, show its schema, and then prompt for JSON parameters to execute it.
+
+### ToolServer
+
+MCP server that exposes tools via HTTP or stdio:
+
+```bash
+$ dotnet run --project ToolServer -- --tools-config Agent/tools.json --working-directory /path/to/project --port 5000
+```
+
+Tools are exposed via the MCP protocol and can be accessed by MCP-compatible clients. Use `--host` to change the listen address (default: `127.0.0.1`).
+
+### AgentManager
+
+Web-based dashboard for managing agents:
+
+```bash
+$ dotnet run --project AgentManager
+```
+
+Access the web UI to manage agents, LXC containers, and Gogs repositories.
+
 ## Contributing
 
 Contributions are welcome! Please open an issue or submit a pull request.
 
 ## License
 
-This project is licensed under the **GNU Affero General Public License v3.0** (AGPL-3.0). 
+This project is licensed under the **GNU Affero General Public License v3.0** (AGPL-3.0).


### PR DESCRIPTION
- Changed Session.Id from Guid to string
- Changed SessionStateEntity.SessionId from Guid to string
- Updated AgentConnection.SessionId from Guid to string
- Removed GUID validation in AgentHub
- Updated all services to use string instead of Guid
- Updated Blazor pages (Sessions, Messages) for string IDs
- Added EF Core migration for schema change

BREAKING: Existing database requires migration for new schema